### PR TITLE
Authorization for Firebase

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,17 @@ workflows:
     jobs:
       - build:
           context: aws
+  weekly:
+    triggers:
+      # Keep the wheels greased (keep builds from aging out of Firebase)
+      - schedule:
+          cron: "8 4 * * MON"
+          filters:
+            branches:
+              only:
+                - main
+    jobs:
+      - build
 
 orbs:
   android: circleci/android@0.2.1
@@ -19,6 +30,9 @@ jobs:
       - checkout:
           path: ~/code
       - aws-cli/install
+      - run:
+          name: Install Firebase credentials
+          command: echo "$GCLOUD_SERVICE_ACCOUNT_JSON" > ~/gcloud.json
       - restore_cache:
           key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
       - run:
@@ -33,7 +47,7 @@ jobs:
           command: ./gradlew assembleDebug
       - run:
           name: Upload build to Firebase
-          command: ./gradlew appDistributionUploadDebug
+          command: GOOGLE_APPLICATION_CREDENTIALS="$HOME"/gcloud.json ./gradlew appDistributionUploadDebug
       - run:
           name: Install lftp command line tool
           command: sudo apt-get update && sudo apt-get install lftp

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,13 +10,14 @@ workflows:
     triggers:
       # Keep the wheels greased (keep builds from aging out of Firebase)
       - schedule:
-          cron: "8 4 * * MON"
+          cron: "8 4 * * 1"
           filters:
             branches:
               only:
                 - main
     jobs:
-      - build
+      - build:
+          context: aws
 
 orbs:
   android: circleci/android@0.2.1

--- a/website/deploy.yml
+++ b/website/deploy.yml
@@ -61,3 +61,41 @@ Resources:
       AliasTarget:
         DNSName: !Sub "${WebsiteCDN.DomainName}"
         HostedZoneId: Z2FDTNDATAQYW2
+
+  WriteWebsiteGroup:
+    Type: AWS::IAM::Group
+    Properties:
+      Path: /websites/
+  WriteWebsitePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      Groups:
+        - !Ref WriteWebsiteGroup
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - s3:GetObject
+              - s3:GetObjectAcl
+              - s3:GetObjectTagging
+              - s3:GetObjectTorrent
+              - s3:GetObjectVersion
+              - s3:GetObjectVersionAcl
+              - s3:GetObjectVersionForReplication
+              - s3:GetObjectVersionTagging
+              - s3:GetObjectVersionTorrent
+              - s3:GetReplicationConfiguration
+              - s3:ListBucket
+              - s3:ListBucketMultipartUploads
+              - s3:ListBucketVersions
+              - s3:ListMultipartUploadParts
+              - s3:ListBucketByTags
+              - s3:PutObject
+              - s3:DeleteObject
+              - s3:PutObjectVersionAcl
+              - s3:PutObjectAcl
+            Resource:
+              - !Sub "${Bucket.Arn}/*"
+              - !Sub "${Bucket.Arn}"
+      PolicyName: !Sub "${AWS::StackName}-write-website"


### PR DESCRIPTION
These configuration changes enables CI. This CI runs using credentials for Firebase and AWS that are scoped down to only allow the opencabstandard example Firebase app and the opencabstandard.org website to be published.

These credentials are not exposed to forked pull requests, so only repository members will have builds and deploys happen automatically.