### PR TITLE
Add direct edit links to GitHub

### DIFF
--- a/OpenCabProvider/app/src/main/java/org/opencabstandard/provider/package-info.java
+++ b/OpenCabProvider/app/src/main/java/org/opencabstandard/provider/package-info.java
@@ -3,6 +3,8 @@
  * <i>providers</i>, the data types communicated to and from those providers, as well as abstract
  * implementations that reduce the boilerplate code needed for an implementation.
  *
+ * <p>You can <a href="https://github.com/opencabstandard/opencab/edit/master/OpenCabProvider/app/src/main/java/org/opencabstandard/provider/package-info.java">propose changes or improvements to this documentation using GitHub.</a>
+ *
  * <h3>Overview</h3>
  *
  * <p>An OpenCab <i>provider</i> is a mechanism for communicating between two Android apps running

--- a/website/overview.html
+++ b/website/overview.html
@@ -5,5 +5,9 @@
     <p>Although this documentation is in the form of a Java API, OpenCab isn't an SDK. Instead, it's a set of agreed-upon Android <a href="https://developer.android.com/reference/android/content/Intent">Intent</a>s and <a href="https://developer.android.com/reference/android/content/ContentProvider">ContentProvider</a>s that, if implemented according to the definitions documented here, permit cross-app communication of structured data without a proprietary SDK.</p>
 
     <p>Check out {@link org.opencabstandard.provider} for the technical details about the types of data that can be shared between apps.</p>
+
+    <p>We welcome pull requests to propose backwards-compatible changes to the spec, clarifications to the spec, and improvements to the sample code via <a href="https://github.com/opencabstandard/opencab">GitHub.</a></p>
+
+    <p>You can <a href="https://github.com/opencabstandard/opencab/edit/master/website/overview.html">propose changes to this file</a> directly.</p>
   </body>
 </html>


### PR DESCRIPTION
There's currently no good way to get from the website to this repo, so this adds some links.