### PR TITLE
Add toggle to change logout action

### DIFF
--- a/OpenCabProvider/app/src/main/java/com/eleostech/exampleprovider/HOSUtil.java
+++ b/OpenCabProvider/app/src/main/java/com/eleostech/exampleprovider/HOSUtil.java
@@ -103,8 +103,9 @@ public class HOSUtil {
         HOSContract.HOSStatusV2 hosStatusV2 = new HOSContract.HOSStatusV2();
         hosStatusV2.setClocks(clocks);
         if (Preferences.isManageAction(context)) {
+            String logoutAction = Preferences.getToggleLogoutAction(context) ? "googlechrome://navigate?url=google.com" : "hos://com.eleostech.opencabprovider/hos";
             hosStatusV2.setManageAction("hos://com.eleostech.opencabprovider/hos");
-            hosStatusV2.setLogoutAction("hos://com.eleostech.opencabprovider/hos");
+            hosStatusV2.setLogoutAction(logoutAction);
         }
         return hosStatusV2;
     }

--- a/OpenCabProvider/app/src/main/java/com/eleostech/exampleprovider/MainActivity.java
+++ b/OpenCabProvider/app/src/main/java/com/eleostech/exampleprovider/MainActivity.java
@@ -126,12 +126,18 @@ public class MainActivity extends AppCompatActivity {
 
         binding.sendManageActionSwitch.setOnClickListener(v -> updateSendManageActionSwitch());
 
+        binding.toggleLogoutActionSwitch.setOnClickListener(v -> updateToggleLogoutActionSwitch());
+
         binding.identityProviderTeamDriverSwitch.setOnClickListener(v -> updateIdentityProviderTeamDriver());
         Preferences.setIdentityResponseToken(this, null);
     }
 
     private void updateSendManageActionSwitch() {
         Preferences.setManageAction(this, binding.sendManageActionSwitch.isChecked());
+    }
+
+    private void updateToggleLogoutActionSwitch() {
+        Preferences.setToggleLogoutAction(this, binding.toggleLogoutActionSwitch.isChecked());
     }
 
     private void saveToken(String text) {

--- a/OpenCabProvider/app/src/main/java/com/eleostech/exampleprovider/Preferences.java
+++ b/OpenCabProvider/app/src/main/java/com/eleostech/exampleprovider/Preferences.java
@@ -29,6 +29,8 @@ public class Preferences {
 
     private static final String PREFS_MANAGE_ACTION = "PREFS_MANAGE_ACTION";
 
+    private static final String PREFS_TOGGLE_LOGOUT_ACTION = "PREFS_TOGGLE_LOGOUT_ACTION";
+
     public static SharedPreferences getPreferences(Context context) {
         return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
     }
@@ -132,6 +134,16 @@ public class Preferences {
 
     public static boolean isIdentityProviderTeamDriverEnabled(Context context) {
         return getPreferences(context).getBoolean(PREFS_IDENTITY_PROVIDER_TEAM_DRIVER, false);
+    }
+
+    public static void setToggleLogoutAction(Context context, boolean logoutAction) {
+        SharedPreferences.Editor editor = getPreferencesEditor(context);
+        editor.putBoolean(PREFS_TOGGLE_LOGOUT_ACTION, logoutAction);
+        editor.commit();
+    }
+
+    public static boolean getToggleLogoutAction(Context context) {
+        return getPreferences(context).getBoolean(PREFS_TOGGLE_LOGOUT_ACTION, false);
     }
 
     public static boolean isManageAction(Context context) {

--- a/OpenCabProvider/app/src/main/res/layout/activity_main.xml
+++ b/OpenCabProvider/app/src/main/res/layout/activity_main.xml
@@ -38,8 +38,8 @@
             android:id="@+id/welcome_user"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="32dp"
-            android:textSize="30sp">
+            android:layout_marginBottom="12dp"
+            android:textSize="25sp">
 
         </TextView>
 
@@ -47,7 +47,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="Duty Status:"
-            android:textSize="24sp"
+            android:textSize="20sp"
             android:textStyle="bold" />
 
         <LinearLayout
@@ -147,7 +147,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="6dp"
-            android:layout_marginTop="16dp"
+            android:layout_marginTop="14dp"
             android:layout_marginEnd="6dp"
             android:text="Enter token here"
             android:visibility="gone" />
@@ -156,7 +156,7 @@
             android:id="@+id/identity_provider_team_driver_switch"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
+            android:layout_marginTop="14dp"
             android:checked="false"
             android:text="Add team driver" />
 
@@ -168,14 +168,23 @@
             android:checked="true"
             android:text="Send manage and login actions" />
 
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/toggle_logout_Action_switch"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="14dp"
+            android:checked="false"
+            android:text="Toggle logout action uri" />
+
         <TextView
             android:id="@+id/hos_clocks_version_text"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentTop="true"
             android:layout_alignParentEnd="true"
-            android:text="Force HOS Version"
-            android:textSize="16dp" />
+            android:text="Force HOS Version:"
+            android:textSize="14dp"
+            android:layout_marginTop="14dp" />
 
         <Spinner
             android:id="@+id/hos_clocks_version_spinner"
@@ -191,6 +200,6 @@
         android:layout_height="wrap_content"
         android:layout_alignParentTop="true"
         android:layout_alignParentEnd="true"
-        android:textSize="20sp" />
+        android:textSize="18sp" />
 
 </RelativeLayout>


### PR DESCRIPTION
Adds a switch to the sample provider that will change the logout action to `googlechrome://navigate?url=google.com` when toggled on. The sample provider sets the logout action and manage action to the same value, so this will allow testing to confirm that they are acting independently.