### PR TITLE
User Switching via HOSContract.METHOD_GET_HOS

### DIFF
--- a/OpenCabConsumer/app/src/main/java/com/eleostech/exampleconsumer/MainActivity.java
+++ b/OpenCabConsumer/app/src/main/java/com/eleostech/exampleconsumer/MainActivity.java
@@ -190,7 +190,7 @@ public class MainActivity extends AppCompatActivity {
                                     if (result.containsKey(HOSContract.KEY_HOS)) {
                                         HOSContract.HOSData hosStatus = gson.fromJson(result.getString(HOSContract.KEY_HOS), HOSContract.HOSData.class);
                                         if (hosStatus != null) {
-                                            adapterHos.insert(dateTime + " : " + "Package: " + provider.packageName + ", Manage Action: " + hosStatus.getManageAction() + ", Logout Action: " + hosStatus.getLogoutAction() + ", KEY_VERSION: " + (result.containsKey(HOSContract.KEY_VERSION) ? result.getString(HOSContract.KEY_VERSION) : "null"), 0);
+                                            adapterHos.insert(dateTime + " : " + "Package: " + provider.packageName + ", Username: " + hosStatus.getUsername() +", Manage Action: " + hosStatus.getManageAction() + ", Logout Action: " + hosStatus.getLogoutAction() + ", KEY_VERSION: " + (result.containsKey(HOSContract.KEY_VERSION) ? result.getString(HOSContract.KEY_VERSION) : "null"), 0);
                                             for (HOSContract.ClockData clock : hosStatus.getClocks()) {
                                                 adapterHos.insert(dateTime + " : " + "Package: " + provider.packageName + ", Label: " + clock.getLabel() + ", Value: " + clock.getValue() + ", Duration: " + clock.getDurationSeconds(), 0);
                                             }

--- a/OpenCabConsumer/app/src/main/java/com/eleostech/exampleconsumer/MainActivity.java
+++ b/OpenCabConsumer/app/src/main/java/com/eleostech/exampleconsumer/MainActivity.java
@@ -105,6 +105,7 @@ public class MainActivity extends AppCompatActivity {
         // See section 4.3 of the specification, "Selecting and calling providers,"
         // for details about this enumeration process.
         List<PackageInfo> packages = getPackageManager().getInstalledPackages(PackageManager.GET_PROVIDERS);
+        adapterHos.clear();
         search:
         for (PackageInfo pkg : packages) {
             if (pkg.providers != null) {
@@ -129,44 +130,93 @@ public class MainActivity extends AppCompatActivity {
                                 Log.d(LOG_TAG, "Got result!");
                                 result.setClassLoader(HOSContract.class.getClassLoader());
 
-                                Version maxSupportedVersion = new Version("0.4");
-                                Version resultVersion;
+                                Version supportedVersionV4 = new Version("0.4");
+                                Version supportedVersionV3 = new Version("0.3");
+                                Version supportedVersionV2 = new Version("0.2");
+                                Version resultVersion = null;
                                 if (result.containsKey(HOSContract.KEY_VERSION) && result.get(HOSContract.KEY_VERSION) != null) {
                                     resultVersion = new Version(result.getString(HOSContract.KEY_VERSION));
                                 } else {
-                                    resultVersion = new Version("0.4");
+                                    resultVersion = supportedVersionV2;
                                 }
-                                if (resultVersion.compareTo(maxSupportedVersion) >= 1) {
-                                    adapterHos.insert(dateTime + " : " + "Version " + resultVersion + " is not supported", 0);
-                                } else if (result.containsKey(HOSContract.KEY_HOS)) {
-                                    HOSContract.HOSData hosStatus = gson.fromJson(result.getString(HOSContract.KEY_HOS), HOSContract.HOSData.class);
-                                    if (hosStatus != null) {
-                                        adapterHos.insert(dateTime + " : " + "Package: " + provider.packageName + ", Manage Action: " + hosStatus.getManageAction() + ", Logout Action: " + hosStatus.getLogoutAction() + ", KEY_VERSION: " + (result.containsKey(HOSContract.KEY_VERSION) ? result.getString(HOSContract.KEY_VERSION) : "null"), 0);
-                                        for (HOSContract.ClockData clock : hosStatus.getClocks()) {
-                                            adapterHos.insert(dateTime + " : " + "Package: " + provider.packageName + ", Label: " + clock.getLabel() + ", Value: " + clock.getValue() + ", Duration: " + clock.getDurationSeconds(), 0);
+                                //Support for version 0.2(before versioning was introduced)
+                                if (resultVersion.compareTo(supportedVersionV2) == 0) {
+                                    if (result.containsKey(HOSContract.KEY_HOS)) {
+                                        HOSContract.HOSStatus hosStatus = result.getParcelable(HOSContract.KEY_HOS);
+                                        if (hosStatus != null) {
+                                            adapterHos.insert(dateTime + " : " + "Package: " + provider.packageName + ", Manage Action: " + hosStatus.getManageAction(), 0);
+                                            for (HOSContract.Clock clock : hosStatus.getClocks()) {
+                                                adapterHos.insert(dateTime + " : " + "Package: " + provider.packageName + ", Label: " + clock.getLabel() + ", Value: " + clock.getValue(), 0);
+                                            }
                                         }
+                                    } else if (result.containsKey(VehicleInformationContract.KEY_ERROR)) {
+                                        String error = result.getString(VehicleInformationContract.KEY_ERROR);
+                                        Log.d(LOG_TAG, "Error: " + error);
+                                        adapterHos.insert(dateTime + " : " + "Package: " + provider.packageName + ", Error: " + error, 0);
                                     }
-                                } else if (result.containsKey(VehicleInformationContract.KEY_ERROR)) {
-                                    String error = result.getString(VehicleInformationContract.KEY_ERROR);
-                                    Log.d(LOG_TAG, "Error: " + error);
-                                    adapterHos.insert(dateTime + " : " + "Package: " + provider.packageName + ", Error: " + error, 0);
-                                }
-                                if (result.containsKey(HOSContract.KEY_TEAM_HOS)) {
-                                    HOSContract.HOSTeamData teamHOSData = gson.fromJson((result.getString(HOSContract.KEY_TEAM_HOS)), HOSContract.HOSTeamData.class);
-                                    ArrayList<HOSContract.HOSData> hosStatusList = teamHOSData.getTeamHosData();
-                                    if (hosStatusList != null && hosStatusList.size() > 0) {
-                                        for (HOSContract.HOSData item : hosStatusList) {
-                                            if (item.getClocks() != null) {
-                                                for (HOSContract.ClockData clock : item.getClocks()) {
-                                                    adapterHos.insert(dateTime + " : " + "Package: " + provider.packageName + ", Label: " + clock.getLabel() + ", Value: " + clock.getValue() + ", Duration: " + clock.getDurationSeconds(), 0);
+                                //Support for Version 0.3
+                                } else if (resultVersion.compareTo(supportedVersionV3) == 0) {
+                                    if (result.containsKey(HOSContract.KEY_HOS)) {
+                                        HOSContract.HOSStatusV2 hosStatus = result.getParcelable(HOSContract.KEY_HOS);
+                                        if (hosStatus != null) {
+                                            adapterHos.insert(dateTime + " : " + "Package: " + provider.packageName + ", Manage Action: " + hosStatus.getManageAction() + ", Logout Action: " + hosStatus.getLogoutAction() + ", KEY_VERSION: " + (result.containsKey(HOSContract.KEY_VERSION) ? result.getString(HOSContract.KEY_VERSION) : "null"), 0);
+                                            for (HOSContract.ClockV2 clock : hosStatus.getClocks()) {
+                                                adapterHos.insert(dateTime + " : " + "Package: " + provider.packageName + ", Label: " + clock.getLabel() + ", Value: " + clock.getValue() + ", Duration: " + clock.getDurationSeconds(), 0);
+                                            }
+                                        }
+                                    } else if (result.containsKey(VehicleInformationContract.KEY_ERROR)) {
+                                        String error = result.getString(VehicleInformationContract.KEY_ERROR);
+                                        Log.d(LOG_TAG, "Error: " + error);
+                                        adapterHos.insert(dateTime + " : " + "Package: " + provider.packageName + ", Error: " + error, 0);
+                                    }
+                                    if (result.containsKey(HOSContract.KEY_TEAM_HOS)) {
+                                        ArrayList<HOSContract.HOSStatusV2> hosStatusList = result.getParcelableArrayList(HOSContract.KEY_TEAM_HOS);
+                                        if (hosStatusList != null && hosStatusList.size() > 0) {
+                                            for (HOSContract.HOSStatusV2 item : hosStatusList) {
+                                                if (item.getClocks() != null) {
+                                                    for (HOSContract.ClockV2 clock : item.getClocks()) {
+                                                        adapterHos.insert(dateTime + " : " + "Package: " + provider.packageName + ", Label: " + clock.getLabel() + ", Value: " + clock.getValue() + ", Duration: " + clock.getDurationSeconds(), 0);
+                                                    }
                                                 }
                                             }
                                         }
+                                    } else if (result.containsKey(VehicleInformationContract.KEY_ERROR)) {
+                                        String error = result.getString(VehicleInformationContract.KEY_ERROR);
+                                        Log.d(LOG_TAG, "Error: " + error);
+                                        adapterHos.insert(dateTime + " : " + "Package: " + provider.packageName + ", Error: " + error, 0);
                                     }
-                                } else if (result.containsKey(VehicleInformationContract.KEY_ERROR)) {
-                                    String error = result.getString(VehicleInformationContract.KEY_ERROR);
-                                    Log.d(LOG_TAG, "Error: " + error);
-                                    adapterHos.insert(dateTime + " : " + "Package: " + provider.packageName + ", Error: " + error, 0);
+                                //Support for Version 0.4
+                                } else if (resultVersion.compareTo(supportedVersionV4) == 0) {
+                                    if (result.containsKey(HOSContract.KEY_HOS)) {
+                                        HOSContract.HOSData hosStatus = gson.fromJson(result.getString(HOSContract.KEY_HOS), HOSContract.HOSData.class);
+                                        if (hosStatus != null) {
+                                            adapterHos.insert(dateTime + " : " + "Package: " + provider.packageName + ", Manage Action: " + hosStatus.getManageAction() + ", Logout Action: " + hosStatus.getLogoutAction() + ", KEY_VERSION: " + (result.containsKey(HOSContract.KEY_VERSION) ? result.getString(HOSContract.KEY_VERSION) : "null"), 0);
+                                            for (HOSContract.ClockData clock : hosStatus.getClocks()) {
+                                                adapterHos.insert(dateTime + " : " + "Package: " + provider.packageName + ", Label: " + clock.getLabel() + ", Value: " + clock.getValue() + ", Duration: " + clock.getDurationSeconds(), 0);
+                                            }
+                                        }
+                                    } else if (result.containsKey(VehicleInformationContract.KEY_ERROR)) {
+                                        String error = result.getString(VehicleInformationContract.KEY_ERROR);
+                                        Log.d(LOG_TAG, "Error: " + error);
+                                        adapterHos.insert(dateTime + " : " + "Package: " + provider.packageName + ", Error: " + error, 0);
+                                    }
+                                    if (result.containsKey(HOSContract.KEY_TEAM_HOS)) {
+                                        HOSContract.HOSTeamData teamHOSData = gson.fromJson((result.getString(HOSContract.KEY_TEAM_HOS)), HOSContract.HOSTeamData.class);
+                                        ArrayList<HOSContract.HOSData> hosStatusList = teamHOSData.getTeamHosData();
+                                        if (hosStatusList != null && hosStatusList.size() > 0) {
+                                            for (HOSContract.HOSData item : hosStatusList) {
+                                                if (item.getClocks() != null) {
+                                                    for (HOSContract.ClockData clock : item.getClocks()) {
+                                                        adapterHos.insert(dateTime + " : " + "Package: " + provider.packageName + ", Label: " + clock.getLabel() + ", Value: " + clock.getValue() + ", Duration: " + clock.getDurationSeconds(), 0);
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    } else if (result.containsKey(VehicleInformationContract.KEY_ERROR)) {
+                                        String error = result.getString(VehicleInformationContract.KEY_ERROR);
+                                        Log.d(LOG_TAG, "Error: " + error);
+                                        adapterHos.insert(dateTime + " : " + "Package: " + provider.packageName + ", Error: " + error, 0);
+                                    }
                                 }
                             } else {
                                 Log.d(LOG_TAG, "Result from provider is null.");

--- a/OpenCabProvider/app/src/main/java/com/eleostech/exampleprovider/HOSProvider.java
+++ b/OpenCabProvider/app/src/main/java/com/eleostech/exampleprovider/HOSProvider.java
@@ -23,8 +23,18 @@ public class HOSProvider extends AbstractHOSProvider {
     }
 
     @Override
+    protected HOSContract.HOSData getHOSData() {
+        return HOSUtil.getHOSData(getContext());
+    }
+
+    @Override
     protected ArrayList<HOSContract.HOSStatusV2> getTeamHOSV2() {
         return HOSUtil.getHOSStatusTeamV2(getContext());
+    }
+
+    @Override
+    protected HOSContract.HOSTeamData getHOSTeamData() {
+        return HOSUtil.getTeamHOSData(getContext());
     }
 
     @Override

--- a/OpenCabProvider/app/src/main/java/org/opencabstandard/provider/AbstractHOSProvider.java
+++ b/OpenCabProvider/app/src/main/java/org/opencabstandard/provider/AbstractHOSProvider.java
@@ -10,6 +10,8 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.google.gson.Gson;
+
 import java.util.ArrayList;
 
 /**
@@ -119,6 +121,7 @@ public abstract class AbstractHOSProvider extends ContentProvider {
                 Version requestedVersion = new Version(getHosVersion() != null ? getHosVersion() : "0.2");
                 Version supportedVersionV2 = new Version("0.2");
                 Version supportedVersionV3 = new Version("0.3");
+                Version supportedVersionV4 = new Version("0.4");
                 Log.i(LOG_TAG, "requested version: " + requestedVersion + ", supported version: " + supportedVersionV2);
                 if (requestedVersion.compareTo(supportedVersionV2) == 0) {
                     HOSContract.HOSStatus status = getHOS();
@@ -128,7 +131,7 @@ public abstract class AbstractHOSProvider extends ContentProvider {
                     } else {
                         result.putString(HOSContract.KEY_ERROR, "Sorry, we are unable to fetch the current HOS.");
                     }
-                } else if (requestedVersion.compareTo(supportedVersionV3) >= 0) {
+                } else if (requestedVersion.compareTo(supportedVersionV3) == 0) {
                     HOSContract.HOSStatusV2 status = getHOSV2();
                     if (status != null) {
                         result.putParcelable(HOSContract.KEY_HOS, status);
@@ -139,6 +142,19 @@ public abstract class AbstractHOSProvider extends ContentProvider {
                     } else {
                         result.putString(HOSContract.KEY_ERROR, "Sorry, we are unable to fetch the current HOS.");
                     }
+                } else if (requestedVersion.compareTo(supportedVersionV4) >= 0) {
+                    Gson gson = new Gson();
+                    HOSContract.HOSData hosData = getHOSData();
+                    if (hosData != null) {
+                        result.putString(HOSContract.KEY_HOS, gson.toJson(hosData));
+                        if (isTeamDriverEnabled()) {
+                            result.putString(HOSContract.KEY_TEAM_HOS, gson.toJson(getHOSTeamData()));
+                        }
+                        result.putString(HOSContract.KEY_VERSION, "0.4");
+                    } else {
+                        result.putString(HOSContract.KEY_ERROR, "Sorry, we are unable to fetch the current HOS.");
+                    }
+
                 }
                 break;
             case HOSContract.METHOD_START_NAVIGATION:
@@ -177,6 +193,19 @@ public abstract class AbstractHOSProvider extends ContentProvider {
      * @return The current HOS
      */
     protected abstract ArrayList<HOSContract.HOSStatusV2> getTeamHOSV2();
+
+    /**
+     * Implement this method to return the current HOSData
+     *
+     * @return The current HOS for version 0.4
+     */
+    protected abstract HOSContract.HOSData getHOSData();
+
+    /**
+     *
+     * @return The current HOS Team Data for version 0.4
+     */
+    protected abstract HOSContract.HOSTeamData getHOSTeamData();
 
     /**
      * Implement this method to indicate when the app started navigation.

--- a/OpenCabProvider/app/src/main/java/org/opencabstandard/provider/HOSContract.java
+++ b/OpenCabProvider/app/src/main/java/org/opencabstandard/provider/HOSContract.java
@@ -4,6 +4,9 @@ import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
 
+import androidx.annotation.NonNull;
+
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -44,7 +47,7 @@ public final class HOSContract {
      * be passed as an argument to all method calls to the provider. The provider may reject or handle
      * appropriately if the VERSION does not match the expected value when passed to the method calls.
      */
-    public static final String VERSION = "0.3";
+    public static final String VERSION = "0.4";
 
     /**
      * This authority is used for querying the HOS provider.  This should be declared in the manifest
@@ -860,5 +863,298 @@ public final class HOSContract {
                 return new ClockV2[size];
             }
         };
+    }
+
+    /**
+     * An object representing the HOS Team Data for version 0.4.
+     */
+    public static class HOSTeamData {
+
+        /**
+         * Get the list of HOSData for the team
+         * @return A list of HOSData objects representing the current team data
+         */
+        public ArrayList<HOSData> getTeamHosData() {
+            return teamHosData;
+        }
+
+        /**
+         * Set the list of HOSData for the team
+         * @param teamHosData - List of current HOSData
+         */
+        public void setTeamHosData(ArrayList<HOSData> teamHosData) {
+            this.teamHosData = teamHosData;
+        }
+
+        private ArrayList<HOSData> teamHosData;
+    }
+
+    /**
+     * An object representing the HOS data for version 0.4
+     */
+    public static class HOSData {
+        private List<ClockData> clocks;
+        private String manageAction;
+        private String logoutAction;
+        private String username;
+
+        public HOSData() {
+
+        }
+
+        /**
+         * The list of current HOS clocks for the driver.
+         *
+         * @return The HOS clocks
+         */
+        public List<ClockData> getClocks() {
+            return clocks;
+        }
+
+        /**
+         * The list of current HOS clocks for the driver.
+         *
+         * @param clocks The HOS clocks
+         */
+        public void setClocks(List<ClockData> clocks) {
+            this.clocks = clocks;
+        }
+
+        /**
+         * A URI string used to launch the OpenCab HOS provider app.
+         *
+         * Providers will launch a {@link android.content.Intent#ACTION_VIEW} intent to open this URI.
+         *
+         * @return The URI string
+         */
+        public String getManageAction() {
+            return manageAction;
+        }
+
+        /**
+         * A URI string to launch the OpenCab HOS provider app.
+         *
+         * Providers will launch a {@link android.content.Intent#ACTION_VIEW} intent to open this URI.
+         *
+         * @param manageAction The URI string
+         */
+        public void setManageAction(String manageAction) {
+            this.manageAction = manageAction;
+        }
+
+        /**
+         * A URI string to launch logout on the OpenCab HOS provider app.
+         *
+         * Providers will launch a {@link android.content.Intent#ACTION_VIEW} intent to open this URI.
+         *
+         * @return The URI string
+         */
+        public String getLogoutAction() {
+            return logoutAction;
+        }
+
+        /**
+         * A URI string to launch logout on the OpenCab HOS provider app.
+         *
+         * Providers will launch a {@link android.content.Intent#ACTION_VIEW} intent to open this URI.
+         *
+         * @param logoutAction The URI string
+         */
+        public void setLogoutAction(String logoutAction) {
+            this.logoutAction = logoutAction;
+        }
+
+        public String getUsername() {
+            return username;
+        }
+
+        public void setUsername(String username) {
+            this.username = username;
+        }
+    }
+
+    /**
+     * Object representing an HOS clock for version 0.4. A clock contains a descriptive label and the value.  The
+     * value can be one of the types defined in the {@link ClockData.ValueType} enum.
+     *
+     * Providers MUST NOT return this data type to a consumer if the consumer has not explicitly signaled support
+     * for at least version 0.4 by passing <pre>"0.4"</pre> to the version parameter of {@link android.content.ContentProvider#call}.
+     *
+     * <p>
+     * An example of the different types of clocks is shown in the image below:
+     * </p>
+     *
+     * <img src="../../../images/clocks-example.png" alt="Hours of service screenshot from the mobile application.">
+     */
+    public static class ClockData {
+        private String label;
+        private String value;
+        private ClockData.ValueType valueType;
+        private boolean important;
+        private boolean limitsDrivingRange;
+        private Double durationSeconds;
+
+        /**
+         * Allowed types for valueType field.
+         */
+        public enum ValueType {
+
+            /**
+             * You can also use a string for an ELD clock duration (like 4:32) if you want to ensure
+             * your own specific rounding and formatting logic is used. In this case, providers SHOULD
+             * provide the actual duration in seconds using the {@link durationSeconds} property. Consumers MUST
+             * display the <code>value</code>, but MAY use {@link durationSeconds} for business logic other than
+             * pure information display.
+             */
+            STRING("string"),
+
+            /**
+             * Indicates that the value field will contain a date in
+             * <a href="https://tools.ietf.org/html/rfc3339">RFC3339</a>
+             * format.  The date will appear formatted as "MM/dd/yyyy".  An example for this type of clock
+             * could be the date of next required truck service.
+             */
+            DATE("date"),
+
+            /**
+             * Indicates that the value field will contain a date in
+             * <a href="https://tools.ietf.org/html/rfc3339">RFC3339</a>
+             * format that will be shown as a clock counting up from the provided date.  An example for this
+             * type of clock could be the number of hours since last rest.
+             */
+            COUNTUP("countup"),
+
+            /**
+             * Indicates that the value field will contain a date in
+             * <a href="https://tools.ietf.org/html/rfc3339">RFC3339</a>
+             * format that will be shown as a clock counting down to zero.  The counter will not go below zero.
+             * An example for this type of clock could be the remaining available drive time.
+             */
+            COUNTDOWN("countdown");
+
+            private final String type;
+
+            ValueType(String t) {
+                type = t;
+            }
+
+            @NonNull
+            public String toString() {
+                return this.type;
+            }
+        }
+
+
+        /**
+         * Label for the clock.
+         *
+         * @param label The clock label.
+         */
+        public void setLabel(String label) {
+            this.label = label;
+        }
+
+        /**
+         * The value of the clock.  The format of this field will depend on the {@link Clock}.valueType field.
+         *
+         * @param value The clock value.
+         */
+        public void setValue(String value) {
+            this.value = value;
+        }
+
+        /**
+         * The value type of the clock.  See {@link ClockData.ValueType} for the possible types.
+         *
+         * @param valueType The valueType for the clock.
+         */
+        public void setValueType(ClockData.ValueType valueType) {
+            this.valueType = valueType;
+        }
+
+        /**
+         * Indicates the important clock. Consumers may interpret this flag in multiple ways,
+         * but one possible use is to determine which clock to display in a compact view
+         * layout that only permits a single clock to be shown.
+         *
+         * @param important Flag indicating which is the most important clock in the list.
+         */
+        public void setImportant(boolean important) {
+            this.important = important;
+        }
+
+        /**
+         * Indicates which clock most tightly limits the time a driver can spend driving.
+         * Consumers may interpret this flag in multiple ways, but one possible use is to
+         * indicate where a driver needs to plan to shut down when planning a route.
+         *
+         * @param limitsDrivingRange Flag indicating which clock limits the driving range.
+         */
+        public void setLimitsDrivingRange(boolean limitsDrivingRange) {
+            this.limitsDrivingRange = limitsDrivingRange;
+        }
+
+        /**
+         * Get the label for the clock.
+         *
+         * @return The label for the clock.
+         */
+        public String getLabel() {
+            return label;
+        }
+
+        /**
+         * Get the value for the clock.
+         *
+         * @return The value for the clock.
+         */
+        public String getValue() {
+            return value;
+        }
+
+        /**
+         * Get the value type
+         *
+         * @return The value type for the clock.
+         */
+        public ClockData.ValueType getValueType() {
+            return valueType;
+        }
+
+        /**
+         * Is the important flag set.
+         *
+         * @return Flag indicating this is the most important clock.
+         */
+        public boolean isImportant() {
+            return important;
+        }
+
+        /**
+         * Is the limitsDrivingRange flag set.
+         *
+         * @return Flag indicating this clock will limit the driving range.
+         */
+        public boolean isLimitsDrivingRange() {
+            return limitsDrivingRange;
+        }
+
+        /**
+         * Get the duration seconds
+         *
+         * @return The duration seconds for the clock.
+         */
+        public Double getDurationSeconds() {
+            return durationSeconds;
+        }
+
+        /**
+         * The duration seconds for the clock.
+         *
+         * @param durationSeconds The duration seconds for the clock.
+         */
+        public void setDurationSeconds(Double durationSeconds) {
+            this.durationSeconds = durationSeconds;
+        }
     }
 }

--- a/OpenCabProvider/app/src/main/res/values/arrays.xml
+++ b/OpenCabProvider/app/src/main/res/values/arrays.xml
@@ -7,6 +7,7 @@
         <item>ACTION_VEHICLE_INFORMATION_CHANGED</item>
     </string-array>
     <string-array name="hos_versions">
+        <item>0.4</item>
         <item>0.3</item>
         <item>0.2</item>
     </string-array>


### PR DESCRIPTION
## Summary
This PR updates the `HOSContract` to version `0.4` to support multi-user logins to allow for driver switching to be reflected in the HOS Consumer application when querying `HOSContract.METHOD_GET_HOS`.

For the HOS Consumer to support the user switching the `KEY_HOS`(sometimes referred to as active driver) will need to know the `username` provided by `IdentityContract.DriverSession.username` during the IdentityConsumers(ELD app) query METHOD_GET_LOGIN_CREDENTIALS.

There is an [ RFC](https://github.com/opencabstandard/opencab/issues/25) currently open for discussion that this work is intended for.
The most notable callout from the RFC is the need to remove `Parcel` as our means of data transfer within `Bundle`. Parcel does not like having missing data if the applications communicating do not have matching Class versions.

We've decided to show the work required for Option 2 on the RFC above as that is the preferred direction we would like to go. This allows us to have less Class name changes in the future to support backwards compatibility.

One change to note below is `HOSTeamData`. To cleanly pass a list of `HOSData` we've now placed that within it's own object called `HOSTeamData` that contains the `ArrayList<HOSData`. This allows the JSON conversion to be called without needing a list conversion or `TypeToken`.

### Data Objects 
Version = 0.4
HOSStatusV2(0.3) -> HOSData(0.4)
HOSClockV2(0.3)  -> ClockData(0.4)
ArrayList<HOSStatusV2>(0.3) -> HOSTeamData(0.4)

HOSData -> Returned from `HOSContract.METHOD_GET_HOS` within `KEY_HOS`
`username` addition
```
{
  "clocks": ClockData[],
  "logoutAction": "",
  "manageAction": "",
  "username":""
}
```

HOSTeamData -> Returned from `HOSContract.METHOD_GET_HOS` within `KEY_TEAM_HOS`
```
{
  "teamHosData": [
    {
      "clocks": ClockData[],
      "logoutAction": "",
      "manageAction": "",
      "username":""
    },
    {},... 
  ]
}
```

### Sample Provider Bundle Call
From the provided Java object
```
HOSData hosData = createHosData(); //Provider implementation of createHosData()
result.putString(HOSContract.KEY_HOS, gson.toJson(hosData));
```
or straight from JSON itself
```
String jsonData = getHOSJson() //Provider generated
result.putString(HOSContract.KEY_HOS, jsonData);
```

### Sample Consumer Bundle Call
```
HOSContract.HOSData hosData = gson.fromJson(result.getString(HOSContract.KEY_HOS), HOSContract.HOSData.class);
```