### PR TITLE
Add HOS response delay toggle

### DIFF
--- a/OpenCabProvider/app/src/main/AndroidManifest.xml
+++ b/OpenCabProvider/app/src/main/AndroidManifest.xml
@@ -25,7 +25,8 @@
         android:theme="@style/AppTheme">
         <activity
             android:name="com.eleostech.exampleprovider.MainActivity"
-            android:exported="true">
+            android:exported="true"
+            android:launchMode="singleInstance">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/OpenCabProvider/app/src/main/java/com/eleostech/exampleprovider/HOSUtil.java
+++ b/OpenCabProvider/app/src/main/java/com/eleostech/exampleprovider/HOSUtil.java
@@ -9,10 +9,14 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 
+import android.util.Log;
+
 public class HOSUtil {
 
 
     private static final String HOS_DURATION_CLOCK_LABEL = "HOS Test Time";
+
+    private static final String LOG_TAG = HOSUtil.class.getCanonicalName();
 
     public static ArrayList<HOSContract.HOSStatusV2> getHOSStatusTeamV2(Context context) {
         ArrayList<HOSContract.HOSStatusV2> response = new ArrayList<>();
@@ -119,6 +123,13 @@ public class HOSUtil {
             hosData.setManageAction("hos://com.eleostech.opencabprovider/hos");
             hosData.setLogoutAction(logoutAction);
         }
+        if (Preferences.getToggleDelayHosResponse(context)) {
+            try {
+                Thread.sleep(15000);
+            } catch (InterruptedException e) {
+                Log.e(LOG_TAG, e.getMessage());
+            }
+        }
         return hosData;
     }
 
@@ -208,6 +219,13 @@ public class HOSUtil {
             hosStatusV2.setManageAction("hos://com.eleostech.opencabprovider/hos");
             hosStatusV2.setLogoutAction(logoutAction);
         }
+        if (Preferences.getToggleDelayHosResponse(context)) {
+            try {
+                Thread.sleep(15000);
+            } catch (InterruptedException e) {
+                Log.e(LOG_TAG, e.getMessage());
+            }
+        }
         return hosStatusV2;
     }
 
@@ -280,6 +298,13 @@ public class HOSUtil {
         hosStatus.setClocks(clocks);
         if (Preferences.isManageAction(context)) {
             hosStatus.setManageAction("hos://com.eleostech.opencabprovider/hos");
+        }
+        if (Preferences.getToggleDelayHosResponse(context)) {
+            try {
+                Thread.sleep(15000);
+            } catch (InterruptedException e) {
+                Log.e(LOG_TAG, e.getMessage());
+            }
         }
         return hosStatus;
     }

--- a/OpenCabProvider/app/src/main/java/com/eleostech/exampleprovider/MainActivity.java
+++ b/OpenCabProvider/app/src/main/java/com/eleostech/exampleprovider/MainActivity.java
@@ -130,10 +130,16 @@ public class MainActivity extends AppCompatActivity {
 
         binding.identityProviderTeamDriverSwitch.setOnClickListener(v -> updateIdentityProviderTeamDriver());
         Preferences.setIdentityResponseToken(this, null);
+
+        binding.toggleDelayHosResponseSwitch.setOnClickListener(v -> updateToggleDelayHosResponseSwitch());
     }
 
     private void updateSendManageActionSwitch() {
         Preferences.setManageAction(this, binding.sendManageActionSwitch.isChecked());
+    }
+
+    private void updateToggleDelayHosResponseSwitch() {
+        Preferences.setToggleDelayHosResponse(this, binding.toggleDelayHosResponseSwitch.isChecked());
     }
 
     private void updateToggleLogoutActionSwitch() {

--- a/OpenCabProvider/app/src/main/java/com/eleostech/exampleprovider/Preferences.java
+++ b/OpenCabProvider/app/src/main/java/com/eleostech/exampleprovider/Preferences.java
@@ -31,6 +31,8 @@ public class Preferences {
 
     private static final String PREFS_TOGGLE_LOGOUT_ACTION = "PREFS_TOGGLE_LOGOUT_ACTION";
 
+    private static final String PREFS_TOGGLE_DELAY_HOS_RESPONSE = "PREFS_TOGGLE_HOS_RESPONSE";
+
     public static SharedPreferences getPreferences(Context context) {
         return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
     }
@@ -144,6 +146,16 @@ public class Preferences {
 
     public static boolean getToggleLogoutAction(Context context) {
         return getPreferences(context).getBoolean(PREFS_TOGGLE_LOGOUT_ACTION, false);
+    }
+
+    public static boolean getToggleDelayHosResponse(Context context) {
+        return getPreferences(context).getBoolean(PREFS_TOGGLE_DELAY_HOS_RESPONSE, false);
+    }
+
+    public static void setToggleDelayHosResponse(Context context, boolean delay) {
+        SharedPreferences.Editor editor = getPreferencesEditor(context);
+        editor.putBoolean(PREFS_TOGGLE_DELAY_HOS_RESPONSE, delay);
+        editor.commit();
     }
 
     public static boolean isManageAction(Context context) {

--- a/OpenCabProvider/app/src/main/res/layout/activity_main.xml
+++ b/OpenCabProvider/app/src/main/res/layout/activity_main.xml
@@ -192,6 +192,14 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp" />
 
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/toggle_delay_hos_response_switch"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="14dp"
+            android:checked="false"
+            android:text="Toggle HOS response delay" />
+
     </LinearLayout>
 
     <TextView


### PR DESCRIPTION
This PR adds a toggle to the example provider that will delay the response to `HOSContract.METHOD_GET_HOS` by 15 seconds when enabled. The primary goal of the toggle is to test that the consuming app can handle a delayed response without any negative effects. 

This also sets the `launchMode` for the example provider to `singleInstance` to ensure that only one instance of the example provider can exist at a time.

https://developer.android.com/guide/components/activities/tasks-and-back-stack#TaskLaunchModes