### PR TITLE
Adjust Provider app UI to allow sending multiple Team drivers

### DIFF
--- a/OpenCabConsumer/app/src/main/res/layout/activity_main.xml
+++ b/OpenCabConsumer/app/src/main/res/layout/activity_main.xml
@@ -15,7 +15,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="Click the button to fetch HOS information."
-            android:textSize="10dp" />
+            android:textSize="12dp" />
 
         <Button
             android:id="@+id/hos_button"
@@ -37,7 +37,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="Click the button to fetch vehicle information."
-            android:textSize="10dp" />
+            android:textSize="12dp" />
 
         <Button
             android:id="@+id/vehicle_information_button"
@@ -59,7 +59,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="Click the button to fetch login credentials."
-            android:textSize="10dp" />
+            android:textSize="12dp" />
 
         <Button
             android:id="@+id/identity_provider_login_credentials_button"
@@ -81,7 +81,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="Click the button to fetch active drivers."
-            android:textSize="10dp" />
+            android:textSize="12dp" />
 
         <Button
             android:id="@+id/identity_active_driver_button"
@@ -103,7 +103,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="View broadcasted events in the list below."
-            android:textSize="10dp" />
+            android:textSize="12dp" />
 
         <ListView
             android:id="@+id/broadcastListView"

--- a/OpenCabProvider/app/src/main/java/com/eleostech/exampleprovider/HOSProvider.java
+++ b/OpenCabProvider/app/src/main/java/com/eleostech/exampleprovider/HOSProvider.java
@@ -61,4 +61,8 @@ public class HOSProvider extends AbstractHOSProvider {
         return Preferences.getHosVersion(getContext());
     }
 
+    @Override
+    protected int getTeamsDriversNumber() {
+        return Preferences.getTeamsDriversNumber(getContext());
+    }
 }

--- a/OpenCabProvider/app/src/main/java/com/eleostech/exampleprovider/HOSUtil.java
+++ b/OpenCabProvider/app/src/main/java/com/eleostech/exampleprovider/HOSUtil.java
@@ -1,6 +1,7 @@
 package com.eleostech.exampleprovider;
 
 import android.content.Context;
+import android.util.Log;
 
 import org.opencabstandard.provider.HOSContract;
 
@@ -9,8 +10,6 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 
-import android.util.Log;
-
 public class HOSUtil {
 
 
@@ -18,17 +17,36 @@ public class HOSUtil {
 
     private static final String LOG_TAG = HOSUtil.class.getCanonicalName();
 
+    /**
+     * If "Add team driver(s) is checked, this will retrieve number of drivers requested and return
+     * an array of {@link HOSContract.HOSStatusV2}
+     * @param context
+     * @return
+     */
     public static ArrayList<HOSContract.HOSStatusV2> getHOSStatusTeamV2(Context context) {
         ArrayList<HOSContract.HOSStatusV2> response = new ArrayList<>();
-        response.add(getHOSStatusV2(context, true, "OPENCAB_TEAM_DRIVER_1"));
-        response.add(getHOSStatusV2(context, true, "OPENCAB_TEAM_DRIVER_2"));
+        if (Preferences.isIdentityProviderTeamDriverEnabled(context)) {
+            for (int i = 0; i < Preferences.getTeamsDriversNumber(context); i++) {
+                //this will return a Team driver with unique name
+                response.add(getHOSStatusV2(context, true, "OPENCAB_TEAM_DRIVER_" + (i + 1)));
+            }
+        }
         return response;
     }
 
+    /**
+     * If "Add team driver(s) is checked, this will retrieve number of drivers requested and return
+     * an array of {@link HOSContract.HOSTeamData}
+     * @param context
+     * @return
+     */
     public static HOSContract.HOSTeamData getTeamHOSData(Context context) {
         ArrayList<HOSContract.HOSData> response = new ArrayList<>();
-        response.add(getHOSData(context, true, "OPENCAB_TEAM_DRIVER_1"));
-        response.add(getHOSData(context, true, "OPENCAB_TEAM_DRIVER_2"));
+        if (Preferences.isIdentityProviderTeamDriverEnabled(context)) {
+            for (int i = 0; i < Preferences.getTeamsDriversNumber(context); i++) {
+                response.add(getHOSData(context, true, "OPENCAB_TEAM_DRIVER_" + (i + 1)));
+            }
+        }
         HOSContract.HOSTeamData data = new HOSContract.HOSTeamData();
         data.setTeamHosData(response);
         return data;
@@ -37,7 +55,6 @@ public class HOSUtil {
     public static HOSContract.HOSData getHOSData(Context context) {
         return getHOSData(context, false, null);
     }
-
 
 
     public static HOSContract.HOSData getHOSData(Context context, boolean isTeamDriver, String userName) {

--- a/OpenCabProvider/app/src/main/java/com/eleostech/exampleprovider/MainActivity.java
+++ b/OpenCabProvider/app/src/main/java/com/eleostech/exampleprovider/MainActivity.java
@@ -89,10 +89,13 @@ public class MainActivity extends AppCompatActivity {
         adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
         binding.broadcastEventSpinner.setAdapter(adapter);
 
-
         ArrayAdapter<CharSequence> adapterHosVersion = ArrayAdapter.createFromResource(this, R.array.hos_versions, android.R.layout.simple_spinner_item);
         adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
         binding.hosClocksVersionSpinner.setAdapter(adapterHosVersion);
+
+        ArrayAdapter<CharSequence> adapterTeamDriversNumber = ArrayAdapter.createFromResource(this, R.array.team_drivers_number, android.R.layout.simple_spinner_item);
+        adapterTeamDriversNumber.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        binding.teamDriversNumberSpinner.setAdapter(adapterTeamDriversNumber);
 
         binding.hosClocksVersionSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
             @Override
@@ -105,6 +108,19 @@ public class MainActivity extends AppCompatActivity {
 
             }
         });
+
+        binding.teamDriversNumberSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+                Preferences.setTeamDriversNumber(getApplicationContext(), Integer.valueOf(binding.teamDriversNumberSpinner.getSelectedItem().toString()));
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> parent) {
+
+            }
+        });
+
         binding.identityProviderTokenTypeSwitch.setOnClickListener(v -> updateIdentityProviderTokenType());
 
         binding.identityProviderTokenTextedit.addTextChangedListener(new TextWatcher() {

--- a/OpenCabProvider/app/src/main/java/com/eleostech/exampleprovider/Preferences.java
+++ b/OpenCabProvider/app/src/main/java/com/eleostech/exampleprovider/Preferences.java
@@ -187,7 +187,7 @@ public class Preferences {
     }
 
     public static int getTeamsDriversNumber(Context context) {
-        return getPreferences(context).getInt(PREFS_TEAM_DRIVERS_NUMBER, 0);
+        return getPreferences(context).getInt(PREFS_TEAM_DRIVERS_NUMBER, 1);
     }
 
 }

--- a/OpenCabProvider/app/src/main/java/com/eleostech/exampleprovider/Preferences.java
+++ b/OpenCabProvider/app/src/main/java/com/eleostech/exampleprovider/Preferences.java
@@ -25,6 +25,8 @@ public class Preferences {
     private static final String PREFS_IDENTITY_PROVIDER_TOKEN = "PREFS_IDENTITY_PROVIDER_TOKEN";
 
     private static final String PREFS_HOS_VERSION = "PREFS_HOS_VERSION";
+
+    private static final String PREFS_TEAM_DRIVERS_NUMBER = "PREFS_TEAM_DRIVERS_NUMBER";
     private static final String PREFS_IDENTITY_PROVIDER_TEAM_DRIVER = "PREFS_IDENTITY_PROVIDER_TEAM_DRIVER";
 
     private static final String PREFS_MANAGE_ACTION = "PREFS_MANAGE_ACTION";
@@ -177,4 +179,15 @@ public class Preferences {
     public static String getHosVersion(Context context) {
         return getPreferences(context).getString(PREFS_HOS_VERSION, null);
     }
+
+    public static void setTeamDriversNumber(Context context, int teamDriversNumber) {
+        SharedPreferences.Editor editor = getPreferencesEditor(context);
+        editor.putInt(PREFS_TEAM_DRIVERS_NUMBER, teamDriversNumber);
+        editor.commit();
+    }
+
+    public static int getTeamsDriversNumber(Context context) {
+        return getPreferences(context).getInt(PREFS_TEAM_DRIVERS_NUMBER, 0);
+    }
+
 }

--- a/OpenCabProvider/app/src/main/java/org/opencabstandard/provider/AbstractHOSProvider.java
+++ b/OpenCabProvider/app/src/main/java/org/opencabstandard/provider/AbstractHOSProvider.java
@@ -237,4 +237,11 @@ public abstract class AbstractHOSProvider extends ContentProvider {
      */
     protected abstract String getHosVersion();
 
+    /**
+     * Implement this to control how many team drivers will be returned to the consumer app.
+     *
+     * @return
+     */
+    protected abstract int getTeamsDriversNumber();
+
 }

--- a/OpenCabProvider/app/src/main/res/layout/activity_main.xml
+++ b/OpenCabProvider/app/src/main/res/layout/activity_main.xml
@@ -158,7 +158,24 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="14dp"
             android:checked="false"
-            android:text="Add team driver" />
+            android:text="Add team driver(s)" />
+
+        <TextView
+            android:id="@+id/team_drivers_number_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentTop="true"
+            android:layout_alignParentEnd="true"
+            android:text="Number of team drivers to send to consumer:"
+            android:textSize="14dp"
+            android:textStyle="bold"
+            android:layout_marginTop="14dp" />
+
+        <Spinner
+            android:id="@+id/team_drivers_number_spinner"
+            android:layout_width="100dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp" />
 
         <androidx.appcompat.widget.SwitchCompat
             android:id="@+id/send_manage_Action_switch"
@@ -184,6 +201,7 @@
             android:layout_alignParentEnd="true"
             android:text="Force HOS Version:"
             android:textSize="14dp"
+            android:textStyle="bold"
             android:layout_marginTop="14dp" />
 
         <Spinner

--- a/OpenCabProvider/app/src/main/res/values/arrays.xml
+++ b/OpenCabProvider/app/src/main/res/values/arrays.xml
@@ -11,4 +11,11 @@
         <item>0.3</item>
         <item>0.2</item>
     </string-array>
+    <string-array name="team_drivers_number">
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
+        <item>5</item>
+    </string-array>
 </resources>


### PR DESCRIPTION
This change adds support for sending multiple team drivers from Provider to Consumer app. There are no changes to contracts. In order to include multiple team drivers user has to enable team driver switch on Provider app and select how many drivers to include in response to consumer app.