### PR TITLE
Remove jcenter repository due to shutdown

### DIFF
--- a/OpenCabConsumer/app/build.gradle
+++ b/OpenCabConsumer/app/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'com.android.volley:volley:1.1.1'
+    implementation 'com.android.volley:volley:1.2.1'
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'de.greenrobot:eventbus:2.2.0'
     implementation 'io.jsonwebtoken:jjwt-gson:0.11.2'

--- a/OpenCabConsumer/build.gradle
+++ b/OpenCabConsumer/build.gradle
@@ -1,8 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
+        mavenCentral()
         google()
-        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.4.2'
@@ -14,8 +14,8 @@ buildscript {
 
 allprojects {
     repositories {
+        mavenCentral()
         google()
-        jcenter()
     }
 }
 

--- a/OpenCabProvider/app/build.gradle
+++ b/OpenCabProvider/app/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'com.android.volley:volley:1.1.1'
+    implementation 'com.android.volley:volley:1.2.1'
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'io.jsonwebtoken:jjwt-gson:0.11.2'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.2'

--- a/OpenCabProvider/build.gradle
+++ b/OpenCabProvider/build.gradle
@@ -1,8 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
+        mavenCentral()
         google()
-        jcenter()
     }
     dependencies {
         classpath "com.android.tools.build:gradle:7.4.2"
@@ -14,8 +14,8 @@ buildscript {
 
 allprojects {
     repositories {
+        mavenCentral()
         google()
-        jcenter()
     }
 }
 


### PR DESCRIPTION
This PR removes the use of jcenter as a dependency source in favor of mavenCentral. A minor bump to volley version `1.2.1` was required as a result of this change.