### PR TITLE
Update weekly trigger filter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ workflows:
           filters:
             branches:
               only:
-                - main
+                - master
     jobs:
       - build_consumer:
           context: aws


### PR DESCRIPTION
Weekly builds were previously configured to run on `main` instead of the correct branch, `master`.